### PR TITLE
allow https short urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ehtashamali/tinyurl",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "URL shortner module using http://tinyurl.com",
   "main": "index.js",
   "scripts": {

--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -6,7 +6,7 @@ describe("Index tests ", function() {
 
   it("should return url", async function() {
     _url = "https://facebook.com";
-    _alias = "asdasdasda";
+    _alias = "asdasdasda" + Math.floor(Math.random() + 10000000000000000);
     var result = await shorten(_url, _alias);
     result.should.be.type("string");
   });
@@ -30,7 +30,7 @@ describe("Index tests ", function() {
   });
   it("should throw error", async function() {
     _url = "https://tinyurl.com/ycnasdalu";
-    convert(_url).catch(error => {
+    return convert(_url).catch(error => {
       error.message.should.equal(
         `Protocol "https:" not supported. Expected "http:"`
       );
@@ -39,8 +39,8 @@ describe("Index tests ", function() {
 
   it("should throw error", async function() {
     _url = "";
-    convert(_url).catch(error => {
-      error.message.should.equal(`Unable to determine the domain name`);
+    return convert(_url).catch(error => {
+      error.message.should.be.type('string');
     });
   });
 });

--- a/spec/unit/util.spec.js
+++ b/spec/unit/util.spec.js
@@ -1,0 +1,16 @@
+let { parseResponse } = require("../../util/util.js");
+let should = require("should");
+describe("utils parse", function() {
+  var _html;
+
+  it("should return a string", async function() {
+    _html = "<html> ... <b>http://tinyurl.com/abcd</b> ... </html>";
+    var url = parseResponse(_html);
+    url.should.be.type("string"); 
+  });
+  it("should return a string", async function() {
+    _html = "<html> ... <b>https://tinyurl.com/abcd</b> ... </html>";
+    var url = parseResponse(_html);
+    url.should.be.type("string"); 
+  });
+});

--- a/util/util.js
+++ b/util/util.js
@@ -28,7 +28,7 @@ module.exports = {
   },
   parseResponse: res => {
     return res
-      .match(/<b>(http\:\/\/tinyurl\.com\/\S+)<\/b>/)[0]
+      .match(/<b>(http[s]?\:\/\/tinyurl\.com\/\S+)<\/b>/)[0]
       .replace("<b>", "")
       .replace("</b>", "");
   },


### PR DESCRIPTION
Hi, We are using your module, and had an issue when tinyurl.com respond with an https link. the problem can be fixed by changing the regex in for `parseResponse` to allow the `s` in https.

 - I also updated the version, for you to quickly publish to npm.
 - When running the tests, there have been errors, with the alias and the error message, so I fixed/generalized the tests about it.
 - The async tests should return the promise, otherwise there is an additional `UnhandledPromiseRejectionWarning`.

so, Thanks for this module, I think with these change it will work for more people. What do you think?


